### PR TITLE
Refactor EventVisibilityService to use Spring Data JPA repository instead of raw SQL

### DIFF
--- a/backend/src/main/java/com/joinmatch/backend/entity/EventVisibility.java
+++ b/backend/src/main/java/com/joinmatch/backend/entity/EventVisibility.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 public class EventVisibility {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
     private String name;

--- a/backend/src/main/java/com/joinmatch/backend/repository/EventVisibilityRepository.java
+++ b/backend/src/main/java/com/joinmatch/backend/repository/EventVisibilityRepository.java
@@ -1,0 +1,7 @@
+package com.joinmatch.backend.repository;
+
+import com.joinmatch.backend.entity.EventVisibility;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventVisibilityRepository extends JpaRepository<EventVisibility, Integer> {
+}


### PR DESCRIPTION
This pull request refactors the EventVisibilityService to leverage Spring Data JPA's repository abstraction instead of using raw SQL via EntityManager.

Changes include:
- Introducing EventVisibilityRepository extending JpaRepository
- Replacing native SQL queries in the service layer with repository method calls
- Simplifying entity persistence logic (e.g., create/update/delete)
- Ensuring ID generation strategy is correctly configured via @GeneratedValue

This improves maintainability, testability, and alignment with Spring best practices.
